### PR TITLE
Fixing infinite scroll issue in mobile view

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "webpack": "^4.6.0",
-    "webpack-cli": "^2.0.15",
+    "webpack-cli": "3.1.1",
     "webpack-dev-server": "^3.1.3"
   },
   "author": "Ajith Kumar VM <ajithkumarvm@gmail.com>",

--- a/src/lib/containers/MunduCarousel.js
+++ b/src/lib/containers/MunduCarousel.js
@@ -244,12 +244,14 @@ class MunduCarousel extends React.Component {
   slideLeft () {
     const {rotateSlides} = this.getProps()
     if(!rotateSlides && this.state.center === 0) {
+      return
     }
     !this.animating && this.animateSlide('left')
   }
   slideRight () {
     const {rotateSlides} = this.getProps()
     if(!rotateSlides && this.state.right === 0) {
+      return
     }
     !this.animating && this.animateSlide('right')
   }


### PR DESCRIPTION
Issue #1 
In slideLeft() and slideRight() returning from the function when (!rotateSlides && this.state.right === 0)